### PR TITLE
Fixed delay bug

### DIFF
--- a/midi.lua
+++ b/midi.lua
@@ -342,7 +342,8 @@ for tick = 1, totalLength do
   end
   if hasEvent then
     local delay = time.calcDelay(tick, lastTick)
-    if delay > 0.05 or computer.uptime() then
+    -- delay % 0.05 == 0 doesn't seem to work
+    if math.floor(delay * 100 + 0.5) % 5 == 0 then
       os.sleep(delay)
     else
       -- Busy idle otherwise, because a sleep will take up to 50ms.


### PR DESCRIPTION
The "or computer.uptime()" part of the condition for calling os.sleep instead of idling was causing the program to always call os.sleep. Also, not only can os.sleep only sleep for times greater than 50ms; it can only sleep for times that are _multiples_ of 50ms, so the delay time is now rounded to hundredths of a second and os.sleep is called if it's a multiple of 50ms.
Songs that previously played at abnormally slow and/or inconsistent speeds now sound much better.